### PR TITLE
Remove unused variable

### DIFF
--- a/0-sandbox-o11y.php
+++ b/0-sandbox-o11y.php
@@ -311,7 +311,7 @@ function sandbox_log_request( $level = 1 ) {
 	$start = microtime( true );
 	if ( $c['end_request'] ) {
 		register_shutdown_function(
-			function() use ( $start, $actions_and_filters_bench, $c ) {
+			function() use ( $start, $c ) {
 				global $wpdb, $wp_object_cache;
 
 				$end     = microtime( true );


### PR DESCRIPTION
This unused variable is causing `wpcut` tests to fail with errors like
```
Fatal error: Uncaught AssertionError: wp_config_output is not empty:
Warning: Undefined variable $actions_and_filters_bench in /home/wpcom/public_html/wp-content/mu-plugins/0-sandbox-o11y.php on line 314
```

I suspect it's related to changing to PHP 8. The unused variable now prints a warning, and that warning is being included in output which `wpcut` checks against some snapshotted output.

The `$actions_and_filters_bench` appears to no longer exist, so no harm removing it.